### PR TITLE
update master 20230521

### DIFF
--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -77,3 +77,17 @@ func IsInvalidError(err error) bool {
 
 	return false
 }
+
+func IsConflictError(err error) bool {
+	if _, ok := err.(gophercloud.ErrDefault409); ok {
+		return true
+	}
+
+	if errCode, ok := err.(gophercloud.ErrUnexpectedResponseCode); ok {
+		if errCode.Actual == http.StatusConflict {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tools/csi-deps-check.sh
+++ b/tools/csi-deps-check.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+# We will check all necessary utils in the image.
+# They all have to launch without errors.
+
+# This utils are using by
+# go mod k8s.io/mount-utils
+/bin/mount -V
+/bin/umount -V
+/sbin/blkid -V
+/sbin/blockdev -V
+/sbin/dumpe2fs -V
+/sbin/fsck --version
+/sbin/mke2fs -V
+/sbin/mkfs.ext4 -V
+/sbin/mkfs.xfs -V
+/usr/sbin/xfs_io -V
+/sbin/xfs_repair -V
+/usr/sbin/xfs_growfs -V
+/bin/btrfs --version
+
+# This utils are using by
+# go mod k8s.io/cloud-provider-openstack/pkg/util/mount
+/bin/udevadm --version
+/bin/findmnt -V

--- a/tools/csi-deps.sh
+++ b/tools/csi-deps.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+#
+# We will copy all dependencies for CSI Node driver to /dest directory
+# all utils are using by cinder-csi-plugin
+# to format/mount/unmount/resize the volumes.
+#
+# It is very important to have slim image,
+# because it runs as root (privileged mode) on the nodes
+#
+
+DEST=/dest
+
+copy_deps() {
+    PROG="$1"
+
+    mkdir -p "${DEST}$(dirname $PROG)"
+
+    if [ -d "${PROG}" ]; then
+        rsync -av "${PROG}/" "${DEST}${PROG}/"
+    else
+        cp -Lv "$PROG" "${DEST}${PROG}"
+    fi
+
+    if [ -x ${PROG} -o $(/usr/bin/ldd "$PROG" >/dev/null) ]; then
+        DEPS="$(/usr/bin/ldd "$PROG" | /bin/grep '=>' | /usr/bin/awk '{ print $3 }')"
+
+        for d in $DEPS; do
+            mkdir -p "${DEST}$(dirname $d)"
+            cp -Lv "$d" "${DEST}${d}"
+        done
+    fi
+}
+
+# Commmon lib /lib64/ld-linux-*.so.2
+# needs for all utils
+mkdir -p ${DEST}/lib64 && cp -Lv /lib64/ld-linux-*.so.2 ${DEST}/lib64/
+
+# This utils are using by
+# go mod k8s.io/mount-utils
+copy_deps /etc/mke2fs.conf
+copy_deps /bin/mount
+copy_deps /bin/umount
+copy_deps /sbin/blkid
+copy_deps /sbin/blockdev
+copy_deps /sbin/dumpe2fs
+copy_deps /sbin/fsck
+copy_deps /sbin/fsck.xfs
+cp /sbin/fsck* ${DEST}/sbin/
+copy_deps /sbin/e2fsck
+# from pkg e2fsprogs - e2image, e2label, e2scrub and etc.
+cp /sbin/e2* ${DEST}/sbin/
+copy_deps /sbin/mke2fs
+copy_deps /sbin/resize2fs
+cp /sbin/mkfs* ${DEST}/sbin/
+copy_deps /sbin/mkfs.xfs
+copy_deps /sbin/xfs_repair
+copy_deps /usr/sbin/xfs_growfs
+copy_deps /usr/sbin/xfs_io
+cp /usr/sbin/xfs* ${DEST}/usr/sbin/
+copy_deps /bin/btrfs
+cp /bin/btrfs* ${DEST}/bin/
+
+# This utils are using by
+# go mod k8s.io/cloud-provider-openstack/pkg/util/mount
+copy_deps /bin/udevadm
+copy_deps /lib/udev/rules.d
+copy_deps /bin/findmnt


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
